### PR TITLE
Singular their instead of his/her bigotry

### DIFF
--- a/src/main/java/org/makeriga/tgbot/features/notifyarrival/ArrivalNotification.java
+++ b/src/main/java/org/makeriga/tgbot/features/notifyarrival/ArrivalNotification.java
@@ -27,6 +27,6 @@ public class ArrivalNotification {
         Date arrivalDate = c.getTime();
         c.add(Calendar.MINUTE, stayMinutes);
         Date leaveDate = c.getTime();
-        return String.format("%s announces his/her arrival - will arrive at %s; will stay until %s.", memberName, Settings.DF__TEXT.format(arrivalDate), Settings.DF__TEXT.format(leaveDate)) + (extraMembers > 0 ? " Extra " + extraMembers + " pers. will come." : "");
+        return String.format("%s announces their arrival - will arrive at %s; will stay until %s.", memberName, Settings.DF__TEXT.format(arrivalDate), Settings.DF__TEXT.format(leaveDate)) + (extraMembers > 0 ? " Extra " + extraMembers + " pers. will come." : "");
     }
 }


### PR DESCRIPTION
A gender neutral or gender inclusive pronoun is a pronoun which does not associate a gender with the individual who is being discussed.

Some languages, such as English, do not have a gender neutral or third gender pronoun available, and this has been criticized, since in many instances, writers, speakers, etc. use “he/his” when referring to a generic individual in the third person. Also, the dichotomy of “he and she” in English does not leave room for other gender identities, which is a source of frustration to the transgender and gender queer communities.

People who are limited by languages which do not include gender neutral pronouns have attempted to create them, in the interest of greater equality.